### PR TITLE
Feature/register token api

### DIFF
--- a/src/main/java/slipp/stalk/controller/MemberTokenController.java
+++ b/src/main/java/slipp/stalk/controller/MemberTokenController.java
@@ -1,0 +1,31 @@
+package slipp.stalk.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import slipp.stalk.controller.dto.TokenDto;
+import slipp.stalk.service.MemberService;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/members/{id}")
+public class MemberTokenController {
+
+    private final MemberService memberService;
+
+    public MemberTokenController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PostMapping("/token")
+    public ResponseEntity<Void> registerToken(@PathVariable long id,
+                                              @RequestBody @Valid TokenDto token) {
+        memberService.registerToken(id, token.getToken());
+        return ResponseEntity.noContent()
+                             .build();
+    }
+}

--- a/src/main/java/slipp/stalk/controller/MemberTokenController.java
+++ b/src/main/java/slipp/stalk/controller/MemberTokenController.java
@@ -1,6 +1,7 @@
 package slipp.stalk.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +26,14 @@ public class MemberTokenController {
     public ResponseEntity<Void> registerToken(@PathVariable long id,
                                               @RequestBody @Valid TokenDto token) {
         memberService.registerToken(id, token.getToken());
+        return ResponseEntity.noContent()
+                             .build();
+    }
+
+    @DeleteMapping("/token")
+    public ResponseEntity<Void> deleteToken(@PathVariable long id,
+                                            @RequestBody @Valid TokenDto token) {
+        memberService.deleteToken(id, token.getToken());
         return ResponseEntity.noContent()
                              .build();
     }

--- a/src/main/java/slipp/stalk/controller/dto/TokenDto.java
+++ b/src/main/java/slipp/stalk/controller/dto/TokenDto.java
@@ -1,0 +1,19 @@
+package slipp.stalk.controller.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+
+@Data
+public class TokenDto {
+
+    @NotEmpty
+    private String token;
+
+    public TokenDto() {
+    }
+
+    public TokenDto(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/slipp/stalk/controller/exceptions/ConflictException.java
+++ b/src/main/java/slipp/stalk/controller/exceptions/ConflictException.java
@@ -1,0 +1,19 @@
+package slipp.stalk.controller.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class ConflictException extends HttpStatusException {
+
+    private static final String MESSAGE = "The request could not be completed due to a conflict with the current state of the target " +
+        "resource";
+
+    @Override
+    public final HttpStatus httpStatus() {
+        return HttpStatus.CONFLICT;
+    }
+
+    @Override
+    public String errorMessage() {
+        return MESSAGE;
+    }
+}

--- a/src/main/java/slipp/stalk/controller/exceptions/TokenAlreadyRegisterException.java
+++ b/src/main/java/slipp/stalk/controller/exceptions/TokenAlreadyRegisterException.java
@@ -1,0 +1,22 @@
+package slipp.stalk.controller.exceptions;
+
+import org.springframework.util.StringUtils;
+
+public class TokenAlreadyRegisterException extends ConflictException {
+
+    private static final String MESSAGE = "%s 토큰은 이미 등록되었습니다";
+
+    private final String token;
+
+    public TokenAlreadyRegisterException(String token) {
+        if (StringUtils.isEmpty(token)) {
+            throw new IllegalArgumentException("token should not be empty");
+        }
+        this.token = token;
+    }
+
+    @Override
+    public String errorMessage() {
+        return String.format(MESSAGE, token);
+    }
+}

--- a/src/main/java/slipp/stalk/controller/exceptions/TokenNotFoundException.java
+++ b/src/main/java/slipp/stalk/controller/exceptions/TokenNotFoundException.java
@@ -1,0 +1,16 @@
+package slipp.stalk.controller.exceptions;
+
+public class TokenNotFoundException extends NotFoundException {
+
+    private static final String MESSAGE = "%s 토큰은 존재하지 않습니다";
+    private final String token;
+
+    public TokenNotFoundException(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public String errorMessage() {
+        return String.format(MESSAGE, token);
+    }
+}

--- a/src/main/java/slipp/stalk/domain/Member.java
+++ b/src/main/java/slipp/stalk/domain/Member.java
@@ -28,10 +28,15 @@ public class Member extends AbstractEntity {
     @Column(name = "MEMBER_EMAIL")
     private String email;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<Token> tokens = new ArrayList<>();
 
     public void addToken(String token) {
         this.tokens.add(new Token(token, this));
+    }
+
+    public boolean deleteToken(Token token) {
+        token.setMember(null);
+        return tokens.remove(token);
     }
 }

--- a/src/main/java/slipp/stalk/domain/Member.java
+++ b/src/main/java/slipp/stalk/domain/Member.java
@@ -4,9 +4,11 @@ import lombok.Getter;
 import lombok.Setter;
 import slipp.stalk.domain.support.AbstractEntity;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -26,6 +28,10 @@ public class Member extends AbstractEntity {
     @Column(name = "MEMBER_EMAIL")
     private String email;
 
-    @OneToMany(mappedBy = "member")
-    private List<Token> tokens;
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Token> tokens = new ArrayList<>();
+
+    public void addToken(String token) {
+        this.tokens.add(new Token(token, this));
+    }
 }

--- a/src/main/java/slipp/stalk/domain/Member.java
+++ b/src/main/java/slipp/stalk/domain/Member.java
@@ -6,6 +6,7 @@ import slipp.stalk.domain.support.AbstractEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.OneToMany;
 import java.util.List;
 
 @Getter
@@ -25,5 +26,6 @@ public class Member extends AbstractEntity {
     @Column(name = "MEMBER_EMAIL")
     private String email;
 
+    @OneToMany(mappedBy = "member")
     private List<Token> tokens;
 }

--- a/src/main/java/slipp/stalk/domain/Member.java
+++ b/src/main/java/slipp/stalk/domain/Member.java
@@ -6,6 +6,7 @@ import slipp.stalk.domain.support.AbstractEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import java.util.List;
 
 @Getter
 @Setter
@@ -23,4 +24,6 @@ public class Member extends AbstractEntity {
 
     @Column(name = "MEMBER_EMAIL")
     private String email;
+
+    private List<Token> tokens;
 }

--- a/src/main/java/slipp/stalk/domain/Token.java
+++ b/src/main/java/slipp/stalk/domain/Token.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import slipp.stalk.domain.support.AbstractEntity;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
@@ -14,9 +15,17 @@ import javax.persistence.ManyToOne;
 @Entity
 public class Token extends AbstractEntity {
 
-    private String token;
-
+    @Column(unique = true)
+    private String value;
     @ManyToOne
     @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "fk_token_member"))
     private Member member;
+
+    public Token() {
+    }
+
+    Token(String value, Member member) {
+        this.value = value;
+        this.member = member;
+    }
 }

--- a/src/main/java/slipp/stalk/domain/Token.java
+++ b/src/main/java/slipp/stalk/domain/Token.java
@@ -1,0 +1,8 @@
+package slipp.stalk.domain;
+
+import lombok.Data;
+
+@Data
+public class Token {
+    private String token;
+}

--- a/src/main/java/slipp/stalk/domain/Token.java
+++ b/src/main/java/slipp/stalk/domain/Token.java
@@ -1,8 +1,22 @@
 package slipp.stalk.domain;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import slipp.stalk.domain.support.AbstractEntity;
 
-@Data
-public class Token {
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Getter
+@Setter
+@Entity
+public class Token extends AbstractEntity {
+
     private String token;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "fk_token_member"))
+    private Member member;
 }

--- a/src/main/java/slipp/stalk/infra/jpa/repository/TokenRepository.java
+++ b/src/main/java/slipp/stalk/infra/jpa/repository/TokenRepository.java
@@ -3,6 +3,8 @@ package slipp.stalk.infra.jpa.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import slipp.stalk.domain.Token;
 
+import java.util.Optional;
+
 public interface TokenRepository extends JpaRepository<Token, Long> {
-    Token findByValue(String value);
+    Optional<Token> findByValue(String value);
 }

--- a/src/main/java/slipp/stalk/infra/jpa/repository/TokenRepository.java
+++ b/src/main/java/slipp/stalk/infra/jpa/repository/TokenRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import slipp.stalk.domain.Token;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
+    Token findByValue(String value);
 }

--- a/src/main/java/slipp/stalk/infra/jpa/repository/TokenRepository.java
+++ b/src/main/java/slipp/stalk/infra/jpa/repository/TokenRepository.java
@@ -1,0 +1,7 @@
+package slipp.stalk.infra.jpa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import slipp.stalk.domain.Token;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+}

--- a/src/main/java/slipp/stalk/service/MemberService.java
+++ b/src/main/java/slipp/stalk/service/MemberService.java
@@ -1,25 +1,39 @@
 package slipp.stalk.service;
 
 import org.springframework.stereotype.Service;
+import slipp.stalk.controller.exceptions.MemberNotFoundException;
+import slipp.stalk.controller.exceptions.TokenAlreadyRegisterException;
 import slipp.stalk.domain.Member;
+import slipp.stalk.domain.Token;
 import slipp.stalk.infra.jpa.repository.MemberRepository;
+import slipp.stalk.infra.jpa.repository.TokenRepository;
 
+import javax.transaction.Transactional;
 import java.util.Optional;
 
 @Service
 public class MemberService {
 
-    private final MemberRepository repository;
+    private final MemberRepository memberRepository;
+    private final TokenRepository tokenRepository;
 
-    public MemberService(MemberRepository repository) {
-        this.repository = repository;
+    public MemberService(MemberRepository memberRepository,
+                         TokenRepository tokenRepository) {
+        this.memberRepository = memberRepository;
+        this.tokenRepository = tokenRepository;
     }
 
     public Optional<Member> get(long id) {
-        return repository.findById(id);
+        return memberRepository.findById(id);
     }
 
+    @Transactional
     public void registerToken(long id, String token) {
-        // TODO : implementation
+        Member m = get(id).orElseThrow(MemberNotFoundException::new);
+        Token t = tokenRepository.findByValue(token);
+        if (t != null) {
+            throw new TokenAlreadyRegisterException(token);
+        }
+        m.addToken(token);
     }
 }

--- a/src/main/java/slipp/stalk/service/MemberService.java
+++ b/src/main/java/slipp/stalk/service/MemberService.java
@@ -18,4 +18,8 @@ public class MemberService {
     public Optional<Member> get(long id) {
         return repository.findById(id);
     }
+
+    public void registerToken(long id, String token) {
+        // TODO : implementation
+    }
 }

--- a/src/test/java/slipp/stalk/controller/MemberControllerTest.java
+++ b/src/test/java/slipp/stalk/controller/MemberControllerTest.java
@@ -1,0 +1,60 @@
+package slipp.stalk.controller;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.modelmapper.ModelMapper;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import slipp.stalk.domain.Member;
+import slipp.stalk.service.MemberService;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class MemberControllerTest {
+
+    private MockMvc mockMvc;
+    private MemberService memberService;
+
+    private long existMemberId = 1L;
+
+    @Before
+    public void setUp() throws Exception {
+        memberService = Mockito.mock(MemberService.class);
+        doReturn(mockMember())
+            .when(memberService).get(existMemberId);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new MemberController(memberService, new ModelMapper()))
+                                 .setControllerAdvice(new RestApiControllerAdvice())
+                                 .build();
+    }
+
+    @Test
+    public void should_return_200_when_member_is_exist() throws Exception {
+        mockMvc.perform(get("/members/" + existMemberId))
+               .andDo(print())
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    public void should_return_404_when_member_is_not_exist() throws Exception {
+        long notExistMemberId = 2L;
+        mockMvc.perform(get("/members/" + notExistMemberId))
+               .andDo(print())
+               .andExpect(status().isNotFound());
+    }
+
+    private Optional<Member> mockMember() {
+        Member member = new Member();
+        member.setMemberId("test");
+        member.setPassword("password");
+        member.setName("gunju");
+        member.setEmail("gunju@slipp.com");
+        return Optional.of(member);
+    }
+}

--- a/src/test/java/slipp/stalk/controller/MemberTokenControllerTest.java
+++ b/src/test/java/slipp/stalk/controller/MemberTokenControllerTest.java
@@ -1,0 +1,102 @@
+package slipp.stalk.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import slipp.stalk.controller.dto.TokenDto;
+import slipp.stalk.controller.exceptions.MemberNotFoundException;
+import slipp.stalk.controller.exceptions.TokenAlreadyRegisterException;
+import slipp.stalk.service.MemberService;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class MemberTokenControllerTest {
+
+    private MockMvc mvc;
+    private MemberService memberService;
+
+    @Before
+    public void setUp() throws Exception {
+        memberService = Mockito.mock(MemberService.class);
+        mvc = MockMvcBuilders.standaloneSetup(new MemberTokenController(memberService))
+                             .setControllerAdvice(new RestApiControllerAdvice())
+                             .build();
+    }
+
+    @Test
+    public void should_return_204_when_register_token_is_succeed() throws Exception {
+        String token = "test token";
+        long memberId = 1;
+
+        mvc.perform(post("/members/{memberId}/token", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(token)))
+           .andDo(print())
+           .andExpect(status().is(204));
+
+        verify(memberService).registerToken(memberId, token);
+    }
+
+    @Test
+    public void should_return_400_when_token_is_empty_string() throws Exception {
+        String token = "";
+        long memberId = 1;
+
+        mvc.perform(post("/members/{memberId}/token", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(token)))
+           .andDo(print())
+           .andExpect(status().is(400));
+
+        verify(memberService, never()).registerToken(memberId, token);
+    }
+
+    @Test
+    public void should_return_404_when_member_is_not_found() throws Exception {
+        String token = "test token";
+        long memberId = 1;
+
+        doThrow(MemberNotFoundException.class)
+            .when(memberService).registerToken(memberId, token);
+
+        mvc.perform(post("/members/{memberId}/token", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(token)))
+           .andDo(print())
+           .andExpect(status().is(404));
+
+        verify(memberService).registerToken(memberId, token);
+    }
+
+    @Test
+    public void should_return_409_when_token_is_already_registered() throws Exception {
+        String token = "test token";
+        long memberId = 1;
+
+        doThrow(TokenAlreadyRegisterException.class)
+            .when(memberService).registerToken(memberId, token);
+
+        mvc.perform(post("/members/{memberId}/token", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(token)))
+           .andDo(print())
+           .andExpect(status().is(409));
+
+        verify(memberService).registerToken(memberId, token);
+    }
+
+    private String body(String token) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(new TokenDto(token));
+    }
+}

--- a/src/test/java/slipp/stalk/controller/MemberTokenControllerTest.java
+++ b/src/test/java/slipp/stalk/controller/MemberTokenControllerTest.java
@@ -11,11 +11,13 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import slipp.stalk.controller.dto.TokenDto;
 import slipp.stalk.controller.exceptions.MemberNotFoundException;
 import slipp.stalk.controller.exceptions.TokenAlreadyRegisterException;
+import slipp.stalk.controller.exceptions.TokenNotFoundException;
 import slipp.stalk.service.MemberService;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -93,6 +95,37 @@ public class MemberTokenControllerTest {
            .andExpect(status().is(409));
 
         verify(memberService).registerToken(memberId, token);
+    }
+
+    @Test
+    public void should_return_204_when_token_is_deleted() throws Exception {
+        String token = "test";
+        long memberId = 1L;
+
+        mvc.perform(delete("/members/{memberId}/token", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(token)))
+           .andDo(print())
+           .andExpect(status().is(204));
+
+        verify(memberService).deleteToken(memberId, token);
+    }
+
+    @Test
+    public void should_return_404_when_token_is_not_found() throws Exception {
+        String token = "test";
+        long memberId = 1L;
+
+        doThrow(TokenNotFoundException.class)
+            .when(memberService).deleteToken(memberId, token);
+
+        mvc.perform(delete("/members/{memberId}/token", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(token)))
+           .andDo(print())
+           .andExpect(status().is(404));
+
+        verify(memberService).deleteToken(memberId, token);
     }
 
     private String body(String token) throws JsonProcessingException {

--- a/src/test/java/slipp/stalk/integration/api/MemberTokenControllerIntegTest.java
+++ b/src/test/java/slipp/stalk/integration/api/MemberTokenControllerIntegTest.java
@@ -1,0 +1,59 @@
+package slipp.stalk.integration.api;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import slipp.stalk.controller.dto.TokenDto;
+import slipp.stalk.controller.exceptions.MemberNotFoundException;
+import slipp.stalk.domain.Member;
+import slipp.stalk.domain.Token;
+import slipp.stalk.infra.jpa.repository.MemberRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class MemberTokenControllerIntegTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    public void registerToken() throws Exception {
+        TokenDto token = new TokenDto("test");
+        long memberId = 1;
+
+        ResponseEntity<Void> response = restTemplate.postForEntity(createUrl(memberId), token, Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+        List<String> tokens = member.getTokens().stream()
+                                    .map(Token::getToken)
+                                    .collect(Collectors.toList());
+
+        assertThat(tokens.contains(token.getToken())).isTrue();
+
+        // TODO : delete resource
+    }
+
+    @Test
+    public void registerToken_fail_if_token_already_exist() throws Exception {
+
+    }
+
+    private String createUrl(long memberId) {
+        return String.format("/members/%s/token", memberId);
+    }
+
+}

--- a/src/test/java/slipp/stalk/integration/api/MemberTokenControllerIntegTest.java
+++ b/src/test/java/slipp/stalk/integration/api/MemberTokenControllerIntegTest.java
@@ -9,27 +9,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 import slipp.stalk.controller.dto.TokenDto;
-import slipp.stalk.controller.exceptions.MemberNotFoundException;
-import slipp.stalk.domain.Member;
-import slipp.stalk.domain.Token;
-import slipp.stalk.infra.jpa.repository.MemberRepository;
 import slipp.stalk.infra.jpa.repository.TokenRepository;
-
-import javax.transaction.Transactional;
-import java.util.Collection;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Transactional
 public class MemberTokenControllerIntegTest {
 
     @Autowired
     private TestRestTemplate restTemplate;
-    @Autowired
-    private MemberRepository memberRepository;
     @Autowired
     private TokenRepository tokenRepository;
 
@@ -41,44 +30,29 @@ public class MemberTokenControllerIntegTest {
         ResponseEntity<Void> response = restTemplate.postForEntity(createUrl(memberId), token, Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-
-        Collection<String> tokens = member.getTokens().stream()
-                                          .map(Token::getToken)
-                                          .collect(Collectors.toSet());
-        assertThat(tokens.contains(token.getToken())).isTrue();
-
-        Token dbToken = member.getTokens().stream()
-                              .filter(t -> t.getToken().equals(token.getToken()))
-                              .findFirst().orElseThrow(IllegalStateException::new);
-
-        tokenRepository.delete(dbToken);
+        deleteToken(token.getToken());
     }
 
     @Test
     public void registerToken_fail_if_token_already_exist() throws Exception {
         TokenDto token = new TokenDto("test");
         long memberId = 1;
-        long tokenId = createToken(token, memberId);
+        createToken(token, memberId);
 
         ResponseEntity<Void> response = restTemplate.postForEntity(createUrl(memberId), token, Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
 
-        deleteToken(tokenId);
+        deleteToken(token.getToken());
     }
 
-    private long createToken(TokenDto token, long memberId) {
-        Token t = new Token();
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-
-        t.setToken(token.getToken());
-        t.setMember(member);
-
-        return tokenRepository.save(t).getId();
+    private void createToken(TokenDto token, long memberId) {
+        ResponseEntity<Void> response = restTemplate.postForEntity(createUrl(memberId), token, Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     }
 
-    private void deleteToken(long tokenId) {
-        tokenRepository.deleteById(tokenId);
+    private void deleteToken(String token) {
+        // TODO : change to API call
+        tokenRepository.deleteById(tokenRepository.findByValue(token).getId());
     }
 
     private String createUrl(long memberId) {

--- a/src/test/java/slipp/stalk/integration/api/MemberTokenControllerIntegTest.java
+++ b/src/test/java/slipp/stalk/integration/api/MemberTokenControllerIntegTest.java
@@ -13,20 +13,25 @@ import slipp.stalk.controller.exceptions.MemberNotFoundException;
 import slipp.stalk.domain.Member;
 import slipp.stalk.domain.Token;
 import slipp.stalk.infra.jpa.repository.MemberRepository;
+import slipp.stalk.infra.jpa.repository.TokenRepository;
 
-import java.util.List;
+import javax.transaction.Transactional;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
 public class MemberTokenControllerIntegTest {
 
     @Autowired
     private TestRestTemplate restTemplate;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private TokenRepository tokenRepository;
 
     @Test
     public void registerToken() throws Exception {
@@ -38,18 +43,42 @@ public class MemberTokenControllerIntegTest {
 
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
-        List<String> tokens = member.getTokens().stream()
-                                    .map(Token::getToken)
-                                    .collect(Collectors.toList());
-
+        Collection<String> tokens = member.getTokens().stream()
+                                          .map(Token::getToken)
+                                          .collect(Collectors.toSet());
         assertThat(tokens.contains(token.getToken())).isTrue();
 
-        // TODO : delete resource
+        Token dbToken = member.getTokens().stream()
+                              .filter(t -> t.getToken().equals(token.getToken()))
+                              .findFirst().orElseThrow(IllegalStateException::new);
+
+        tokenRepository.delete(dbToken);
     }
 
     @Test
     public void registerToken_fail_if_token_already_exist() throws Exception {
+        TokenDto token = new TokenDto("test");
+        long memberId = 1;
+        long tokenId = createToken(token, memberId);
 
+        ResponseEntity<Void> response = restTemplate.postForEntity(createUrl(memberId), token, Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+
+        deleteToken(tokenId);
+    }
+
+    private long createToken(TokenDto token, long memberId) {
+        Token t = new Token();
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+        t.setToken(token.getToken());
+        t.setMember(member);
+
+        return tokenRepository.save(t).getId();
+    }
+
+    private void deleteToken(long tokenId) {
+        tokenRepository.deleteById(tokenId);
     }
 
     private String createUrl(long memberId) {

--- a/src/test/java/slipp/stalk/integration/api/MemberTokenControllerIntegTest.java
+++ b/src/test/java/slipp/stalk/integration/api/MemberTokenControllerIntegTest.java
@@ -5,10 +5,13 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 import slipp.stalk.controller.dto.TokenDto;
+import slipp.stalk.domain.Token;
 import slipp.stalk.infra.jpa.repository.TokenRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,38 +28,54 @@ public class MemberTokenControllerIntegTest {
     @Test
     public void registerToken() throws Exception {
         TokenDto token = new TokenDto("test");
-        long memberId = 1;
+        long id = 1;
 
-        ResponseEntity<Void> response = restTemplate.postForEntity(createUrl(memberId), token, Void.class);
+        ResponseEntity<Void> response = restTemplate.postForEntity(createUrl(id), token, Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(memberHasToken(id, token)).isTrue();
 
-        deleteToken(token.getToken());
+        deleteToken(token, id);
+
+        assertThat(memberHasToken(id, token)).isFalse();
     }
 
     @Test
     public void registerToken_fail_if_token_already_exist() throws Exception {
         TokenDto token = new TokenDto("test");
-        long memberId = 1;
-        createToken(token, memberId);
+        long id = 1;
+        createToken(token, id);
 
-        ResponseEntity<Void> response = restTemplate.postForEntity(createUrl(memberId), token, Void.class);
+        ResponseEntity<Void> response = restTemplate.postForEntity(createUrl(id), token, Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(memberHasToken(id, token)).isTrue();
 
-        deleteToken(token.getToken());
+        deleteToken(token, id);
+        assertThat(memberHasToken(id, token)).isFalse();
     }
 
-    private void createToken(TokenDto token, long memberId) {
-        ResponseEntity<Void> response = restTemplate.postForEntity(createUrl(memberId), token, Void.class);
+    private boolean memberHasToken(long id, TokenDto token) {
+        Token t = tokenRepository.findByValue(token.getToken()).orElse(null);
+        if (t == null) {
+            return false;
+        }
+        return t.getMember().getId() == id;
+    }
+
+    private void createToken(TokenDto token, long id) {
+        ResponseEntity<Void> response = restTemplate.postForEntity(createUrl(id), token, Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     }
 
-    private void deleteToken(String token) {
-        // TODO : change to API call
-        tokenRepository.deleteById(tokenRepository.findByValue(token).getId());
+    private void deleteToken(TokenDto token, long id) {
+        ResponseEntity<Void> response = restTemplate.exchange(createUrl(id),
+                                                              HttpMethod.DELETE,
+                                                              new HttpEntity<>(token),
+                                                              Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     }
 
-    private String createUrl(long memberId) {
-        return String.format("/members/%s/token", memberId);
+    private String createUrl(long id) {
+        return String.format("/members/%s/token", id);
     }
 
 }

--- a/src/test/java/slipp/stalk/service/MemberServiceTest.java
+++ b/src/test/java/slipp/stalk/service/MemberServiceTest.java
@@ -5,10 +5,12 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import slipp.stalk.controller.exceptions.MemberNotFoundException;
 import slipp.stalk.controller.exceptions.TokenAlreadyRegisterException;
+import slipp.stalk.controller.exceptions.TokenNotFoundException;
 import slipp.stalk.domain.Member;
 import slipp.stalk.infra.jpa.repository.MemberRepository;
 import slipp.stalk.infra.jpa.repository.TokenRepository;
 import slipp.stalk.support.DataJpaIntegrationTest;
+import slipp.stalk.support.MemberTestMother;
 
 import java.util.Optional;
 
@@ -30,21 +32,21 @@ public class MemberServiceTest extends DataJpaIntegrationTest {
     }
 
     @Test
-    public void return_empty_optional_when_member_is_not_exist() {
+    public void get__return_empty_optional_when_member_is_not_exist() {
         long notExistMemberId = id + 100;
         Optional<Member> member = service.get(notExistMemberId);
         assertThat(member.isPresent()).isFalse();
     }
 
     @Test
-    public void return_member_when_member_is_exist() {
+    public void get__return_member_when_member_is_exist() {
         Optional<Member> member = service.get(id);
         assertThat(member.isPresent()).isTrue();
         assertThat(member.get().getMemberId()).isEqualTo("gunju");
     }
 
     @Test
-    public void should_register_token() {
+    public void registerToken__should_register_token() {
         String token = "token";
         service.registerToken(id, token);
 
@@ -52,7 +54,7 @@ public class MemberServiceTest extends DataJpaIntegrationTest {
     }
 
     @Test
-    public void should_throw_MemberNotFoundException_when_member_is_not_exist() throws Exception {
+    public void registerToken__should_throw_MemberNotFoundException_when_member_is_not_exist() throws Exception {
         long notExistMemberId = id + 100;
         String token = "token";
         Throwable t = catchThrowable(() -> service.registerToken(notExistMemberId, token));
@@ -60,12 +62,58 @@ public class MemberServiceTest extends DataJpaIntegrationTest {
     }
 
     @Test
-    public void should_throw_TokenAlreadyExistException_when_token_is_already_exist() throws Exception {
+    public void registerToken__should_throw_TokenAlreadyExistException_when_token_is_already_exist() throws Exception {
         String token = "token";
 
         service.registerToken(id, token);
         Throwable t = catchThrowable(() -> service.registerToken(id, token));
         assertThat(t).isInstanceOf(TokenAlreadyRegisterException.class);
+    }
+
+    @Test
+    public void deleteToken__should_throw_TokenNotFoundException_when_token_is_not_exist() throws Exception {
+        String notExistToken = "token";
+
+        Throwable t = catchThrowable(() -> service.deleteToken(id, notExistToken));
+        assertThat(t).isInstanceOf(TokenNotFoundException.class);
+    }
+
+    @Test
+    public void deleteToken__should_throw_TokenNotFoundException_when_member_doesnt_has_that_token() throws Exception {
+        String token = "token";
+        registerToken(id, token);
+
+        long newId = saveTestData(MemberTestMother.memberBuilder()
+                                                  .email("gunjuko@gmail.com")
+                                                  .memberId("new member")
+                                                  .name("gunju ko")
+                                                  .password("test")
+                                                  .build()).getId();
+
+        Throwable t = catchThrowable(() -> service.deleteToken(newId, token));
+        assertThat(t).isInstanceOf(TokenNotFoundException.class);
+    }
+
+    @Test
+    public void deleteToken__should_throw_MemberNotFoundException_when_token_is_not_exist() throws Exception {
+        String token = "token";
+        long notExistMemberId = id + 100;
+
+        Throwable t = catchThrowable(() -> service.deleteToken(notExistMemberId, token));
+        assertThat(t).isInstanceOf(MemberNotFoundException.class);
+    }
+
+    @Test
+    public void deleteToken__should_delete_token() throws Exception {
+        String token = "token";
+        registerToken(id, token);
+
+        service.deleteToken(id, token);
+        assertThat(memberHasToken(find(Member.class, id), token)).isFalse();
+    }
+
+    private void registerToken(long id, String token) {
+        service.registerToken(id, token);
     }
 
     private boolean memberHasToken(Member m, String token) {

--- a/src/test/java/slipp/stalk/support/DataJpaIntegrationTest.java
+++ b/src/test/java/slipp/stalk/support/DataJpaIntegrationTest.java
@@ -15,6 +15,12 @@ public abstract class DataJpaIntegrationTest {
 
     public <T> T saveTestData(T entity) {
         assert entity != null;
-        return entityManager.persist(entity);
+        T result = entityManager.persist(entity);
+        entityManager.flush();
+        return result;
+    }
+
+    public <T> T find(Class<T> clazz, Object key) {
+        return entityManager.find(clazz, key);
     }
 }


### PR DESCRIPTION
회원의 토큰 생성 및 토큰 삭제 API를 구현했습니다.

* 토큰 생성 : POST /members/{id}/token
* 토큰 삭제 : DELETE /members/{id}/token

토큰은 Request Body를 통해서 넘겨주어야 합니다. Request Body는 JSON 형식으로 아래와 같이 token 값을 넘겨주면 됩니다.

``` json
{
	"token" : "test"
}
```

아래는 curl 샘플 예제입니다.

#### 토큰 생성

```
curl -X POST \
  http://localhost:8080/members/1/token \
  -H 'Content-Type: application/json' \
  -d '{
	"token" : "test"
}'
```

#### 토큰 삭제

```
curl -X DELETE \
  http://localhost:8080/members/1/token \
  -H 'Content-Type: application/json' \
  -d '{
	"token" : "test"
}'
```

> 존재하지 않는 회원이거나, 예외적인 상황에서는 4XX 에러가 발생합니다.