### PR TITLE
회원 추가 API 개발

### DIFF
--- a/src/main/java/slipp/stalk/controller/MemberController.java
+++ b/src/main/java/slipp/stalk/controller/MemberController.java
@@ -1,18 +1,25 @@
 package slipp.stalk.controller;
 
 import org.modelmapper.ModelMapper;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import slipp.stalk.controller.dto.CreateMemberDto;
 import slipp.stalk.controller.dto.MemberDto;
 import slipp.stalk.controller.exceptions.MemberNotFoundException;
 import slipp.stalk.domain.Member;
 import slipp.stalk.service.MemberService;
 
+import javax.validation.Valid;
+
 @RestController
-@RequestMapping("/members/")
+@RequestMapping("/members")
 public class MemberController {
 
     private final MemberService memberService;
@@ -23,11 +30,28 @@ public class MemberController {
         this.modelMapper = modelMapper;
     }
 
-    @GetMapping("{id}")
+    @GetMapping("/{id}")
     public ResponseEntity<MemberDto> get(@PathVariable long id) {
         Member member = memberService.get(id)
                                      .orElseThrow(MemberNotFoundException::new);
         return ResponseEntity.ok(mapToMemberDto(member));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestBody @Valid CreateMemberDto body) {
+        MemberDto member = mapToMemberDto(memberService.create(mapToMember(body)));
+        return new ResponseEntity<>(member.makeHttpHeaders(), HttpStatus.NO_CONTENT);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable long id) {
+        // TODO : implementation
+        return ResponseEntity.noContent()
+                             .build();
+    }
+
+    private Member mapToMember(CreateMemberDto body) {
+        return modelMapper.map(body, Member.class);
     }
 
     private MemberDto mapToMemberDto(Member member) {

--- a/src/main/java/slipp/stalk/controller/dto/CreateMemberDto.java
+++ b/src/main/java/slipp/stalk/controller/dto/CreateMemberDto.java
@@ -1,0 +1,18 @@
+package slipp.stalk.controller.dto;
+
+import lombok.Data;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.Email;
+
+@Data
+public class CreateMemberDto {
+    @Length(min = 4, max = 15)
+    private String memberId;
+    @Length(min = 6, max = 15)
+    private String password;
+    @Length(min = 2, max = 15)
+    private String name;
+    @Email
+    private String email;
+}

--- a/src/main/java/slipp/stalk/controller/dto/MemberDto.java
+++ b/src/main/java/slipp/stalk/controller/dto/MemberDto.java
@@ -2,10 +2,17 @@ package slipp.stalk.controller.dto;
 
 import lombok.Data;
 
+import java.net.URI;
+
 @Data
-public class MemberDto {
+public class MemberDto implements UrlGeneratable {
+    private long id;
     private String memberId;
-    private String password;
     private String name;
     private String email;
+
+    @Override
+    public URI generateApiUri() {
+        return URI.create("/members/" + id);
+    }
 }

--- a/src/main/java/slipp/stalk/controller/dto/UrlGeneratable.java
+++ b/src/main/java/slipp/stalk/controller/dto/UrlGeneratable.java
@@ -1,0 +1,16 @@
+package slipp.stalk.controller.dto;
+
+import org.springframework.http.HttpHeaders;
+
+import java.net.URI;
+
+public interface UrlGeneratable {
+    URI generateApiUri();
+
+    default HttpHeaders makeHttpHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(generateApiUri());
+
+        return headers;
+    }
+}

--- a/src/main/java/slipp/stalk/controller/exceptions/MemberIdAlreadyExistException.java
+++ b/src/main/java/slipp/stalk/controller/exceptions/MemberIdAlreadyExistException.java
@@ -1,0 +1,19 @@
+package slipp.stalk.controller.exceptions;
+
+import org.springframework.util.StringUtils;
+
+public class MemberIdAlreadyExistException extends ConflictException {
+    private final String memberId;
+
+    public MemberIdAlreadyExistException(String memberId) {
+        if (StringUtils.isEmpty(memberId)) {
+            throw new IllegalArgumentException("memberId should not be empty");
+        }
+        this.memberId = memberId;
+    }
+
+    @Override
+    public String errorMessage() {
+        return String.format("%s는 이미 존재하는 회원 아이디입니다", memberId);
+    }
+}

--- a/src/main/java/slipp/stalk/infra/jpa/repository/MemberRepository.java
+++ b/src/main/java/slipp/stalk/infra/jpa/repository/MemberRepository.java
@@ -3,5 +3,8 @@ package slipp.stalk.infra.jpa.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import slipp.stalk.domain.Member;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByMemberId(String memberId);
 }

--- a/src/main/java/slipp/stalk/service/MemberService.java
+++ b/src/main/java/slipp/stalk/service/MemberService.java
@@ -1,6 +1,7 @@
 package slipp.stalk.service;
 
 import org.springframework.stereotype.Service;
+import slipp.stalk.controller.exceptions.MemberIdAlreadyExistException;
 import slipp.stalk.controller.exceptions.MemberNotFoundException;
 import slipp.stalk.controller.exceptions.TokenAlreadyRegisterException;
 import slipp.stalk.controller.exceptions.TokenNotFoundException;
@@ -26,6 +27,15 @@ public class MemberService {
 
     public Optional<Member> get(long id) {
         return memberRepository.findById(id);
+    }
+
+    @Transactional
+    public Member create(Member body) {
+        memberRepository.findByMemberId(body.getMemberId())
+                        .ifPresent(t -> {
+                            throw new MemberIdAlreadyExistException(t.getMemberId());
+                        });
+        return memberRepository.save(body);
     }
 
     @Transactional

--- a/src/main/resources/data-h2.sql
+++ b/src/main/resources/data-h2.sql
@@ -1,1 +1,1 @@
-INSERT INTO member (id, MEMBER_ID, MEMBER_PASSWORD, MEMBER_NAME, MEMBER_EMAIL) values (1, 'gunju', 'test', '고건주', 'gunjuko92@gmail.com');
+INSERT INTO member (ID, MEMBER_ID, MEMBER_PASSWORD, MEMBER_NAME, MEMBER_EMAIL) values ((select next value for hibernate_sequence), 'gunju', 'test', '고건주', 'gunjuko92@gmail.com');

--- a/src/test/java/slipp/stalk/controller/MemberControllerTest.java
+++ b/src/test/java/slipp/stalk/controller/MemberControllerTest.java
@@ -1,11 +1,15 @@
 package slipp.stalk.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import slipp.stalk.controller.dto.CreateMemberDto;
 import slipp.stalk.domain.Member;
 import slipp.stalk.service.MemberService;
 
@@ -13,6 +17,7 @@ import java.util.Optional;
 
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -47,6 +52,44 @@ public class MemberControllerTest {
         mockMvc.perform(get("/members/" + notExistMemberId))
                .andDo(print())
                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void should_return_400_when_email_format_is_not_valid() throws Exception {
+        CreateMemberDto body = mockCreateMemberDto();
+        body.setEmail("wrong email");
+
+        mockMvc.perform(post("/members")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(writeBodyAsString(body)))
+               .andDo(print())
+               .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void should_return_400_when_memberId_is_too_short() throws Exception {
+        CreateMemberDto body = mockCreateMemberDto();
+        body.setMemberId("ab");
+
+        mockMvc.perform(post("/members")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(writeBodyAsString(body)))
+               .andDo(print())
+               .andExpect(status().isBadRequest());
+    }
+
+    private String writeBodyAsString(Object body) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(body);
+    }
+
+    private CreateMemberDto mockCreateMemberDto() {
+        CreateMemberDto body = new CreateMemberDto();
+        body.setEmail("gunju@slipp.com");
+        body.setMemberId("gunju");
+        body.setName("고건주");
+        body.setPassword("password");
+        return body;
     }
 
     private Optional<Member> mockMember() {

--- a/src/test/java/slipp/stalk/integration/api/MemberControllerIntegTest.java
+++ b/src/test/java/slipp/stalk/integration/api/MemberControllerIntegTest.java
@@ -1,0 +1,67 @@
+package slipp.stalk.integration.api;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import slipp.stalk.controller.dto.CreateMemberDto;
+import slipp.stalk.controller.dto.MemberDto;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class MemberControllerIntegTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    public void should_create_new_member() throws Exception {
+        CreateMemberDto body = createBody("slipp");
+        String path = createResource("/members", body);
+
+        ResponseEntity<MemberDto> response = restTemplate.getForEntity(path, MemberDto.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        MemberDto responseBody = response.getBody();
+        assertThat(responseBody).isNotNull();
+        assertThat(responseBody.getMemberId()).isEqualTo(body.getMemberId());
+        assertThat(responseBody.getName()).isEqualTo(body.getName());
+        assertThat(responseBody.getEmail()).isEqualTo(body.getEmail());
+
+        deleteResource(path);
+    }
+
+    @Test
+    public void should_return_409_when_memberId_isAlready_exist() throws Exception {
+        CreateMemberDto body = createBody("gunju");
+        ResponseEntity<Void> response = restTemplate.postForEntity("/members", body, Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    private String createResource(String path, Object body) {
+        ResponseEntity<Void> response = restTemplate.postForEntity(path, body, Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        return response.getHeaders().getLocation().getPath();
+    }
+
+    private void deleteResource(String path) {
+        ResponseEntity<Void> response = restTemplate.exchange(path, HttpMethod.DELETE, null, Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+
+    private CreateMemberDto createBody(String memberId) {
+        CreateMemberDto body = new CreateMemberDto();
+        body.setMemberId(memberId);
+        body.setPassword("password");
+        body.setName("hi");
+        body.setEmail(memberId + "@naver.com");
+        return body;
+    }
+}

--- a/src/test/java/slipp/stalk/service/MemberServiceTest.java
+++ b/src/test/java/slipp/stalk/service/MemberServiceTest.java
@@ -3,6 +3,7 @@ package slipp.stalk.service;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import slipp.stalk.controller.exceptions.MemberIdAlreadyExistException;
 import slipp.stalk.controller.exceptions.MemberNotFoundException;
 import slipp.stalk.controller.exceptions.TokenAlreadyRegisterException;
 import slipp.stalk.controller.exceptions.TokenNotFoundException;
@@ -110,6 +111,31 @@ public class MemberServiceTest extends DataJpaIntegrationTest {
 
         service.deleteToken(id, token);
         assertThat(memberHasToken(find(Member.class, id), token)).isFalse();
+    }
+
+    @Test
+    public void create__should_throw_MemberIdAlreadyExistException_when_memberId_is_already_exist() throws Exception {
+        Member member = createMember("gunju");
+
+        Throwable t = catchThrowable(() -> service.create(member));
+        assertThat(t).isInstanceOf(MemberIdAlreadyExistException.class);
+    }
+
+    @Test
+    public void create__should_create_new_member() throws Exception {
+        Member member = createMember("slipp");
+
+        Member result = service.create(member);
+        assertThat(result.getMemberId()).isEqualTo(member.getMemberId());
+    }
+
+    private Member createMember(String memberId) {
+        Member member = new Member();
+        member.setMemberId(memberId);
+        member.setPassword("password");
+        member.setName("무명");
+        member.setEmail(memberId + "@naver.com");
+        return member;
     }
 
     private void registerToken(long id, String token) {


### PR DESCRIPTION
### Description
* 회원 추가 API를 개발했습니다. 자세한 내용은 MemberController 부분을 참고하시길 바랍니다.
* POST "/members"로 새로운 회원은 추가할 수 있습니다. 아래는 간단한 샘플입니다.
  * 단 memberId는 겹치면 안되며, email 형식이 올바르지 못한 경우에는 status로 400이 나갑니다.

### Example

##### curl

```
curl -X POST \
  http://localhost:8080/members \
  -H 'Content-Type: application/json' \
  -d '{
	"memberId": "gunju3",
	"password": "test123",
	"name": "고건주",
	"email": "rhrjswn2@naver.com"
}'
```