### PR TITLE
회원 테이블에서 member_id 필드 삭제

### DIFF
--- a/src/main/java/slipp/stalk/controller/MemberController.java
+++ b/src/main/java/slipp/stalk/controller/MemberController.java
@@ -38,9 +38,9 @@ public class MemberController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> create(@RequestBody @Valid CreateMemberDto body) {
+    public ResponseEntity<MemberDto> create(@RequestBody @Valid CreateMemberDto body) {
         MemberDto member = mapToMemberDto(memberService.create(mapToMember(body)));
-        return new ResponseEntity<>(member.makeHttpHeaders(), HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(member, member.makeHttpHeaders(), HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/slipp/stalk/controller/dto/CreateMemberDto.java
+++ b/src/main/java/slipp/stalk/controller/dto/CreateMemberDto.java
@@ -7,12 +7,10 @@ import javax.validation.constraints.Email;
 
 @Data
 public class CreateMemberDto {
-    @Length(min = 4, max = 15)
-    private String memberId;
-    @Length(min = 6, max = 15)
-    private String password;
     @Length(min = 2, max = 15)
     private String name;
     @Email
     private String email;
+    @Length(min = 6, max = 15)
+    private String password;
 }

--- a/src/main/java/slipp/stalk/controller/dto/MemberDto.java
+++ b/src/main/java/slipp/stalk/controller/dto/MemberDto.java
@@ -7,7 +7,6 @@ import java.net.URI;
 @Data
 public class MemberDto implements UrlGeneratable {
     private long id;
-    private String memberId;
     private String name;
     private String email;
 

--- a/src/main/java/slipp/stalk/controller/exceptions/MemberEmailAlreadyExistException.java
+++ b/src/main/java/slipp/stalk/controller/exceptions/MemberEmailAlreadyExistException.java
@@ -2,10 +2,10 @@ package slipp.stalk.controller.exceptions;
 
 import org.springframework.util.StringUtils;
 
-public class MemberIdAlreadyExistException extends ConflictException {
+public class MemberEmailAlreadyExistException extends ConflictException {
     private final String memberId;
 
-    public MemberIdAlreadyExistException(String memberId) {
+    public MemberEmailAlreadyExistException(String memberId) {
         if (StringUtils.isEmpty(memberId)) {
             throw new IllegalArgumentException("memberId should not be empty");
         }
@@ -14,6 +14,6 @@ public class MemberIdAlreadyExistException extends ConflictException {
 
     @Override
     public String errorMessage() {
-        return String.format("%s는 이미 존재하는 회원 아이디입니다", memberId);
+        return String.format("%s는 이미 존재하는 회원 이메일입니다", memberId);
     }
 }

--- a/src/main/java/slipp/stalk/domain/Member.java
+++ b/src/main/java/slipp/stalk/domain/Member.java
@@ -16,18 +16,12 @@ import java.util.List;
 @Entity
 public class Member extends AbstractEntity {
 
-    @Column(name = "MEMBER_ID", unique = true, nullable = false)
-    private String memberId;
-
-    @Column(name = "MEMBER_PASSWORD", nullable = false)
-    private String password;
-
     @Column(name = "MEMBER_NAME", nullable = false)
     private String name;
-
     @Column(name = "MEMBER_EMAIL")
     private String email;
-
+    @Column(name = "MEMBER_PASSWORD", nullable = false)
+    private String password;
     @OneToMany(mappedBy = "member", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<Token> tokens = new ArrayList<>();
 

--- a/src/main/java/slipp/stalk/infra/jpa/repository/MemberRepository.java
+++ b/src/main/java/slipp/stalk/infra/jpa/repository/MemberRepository.java
@@ -6,5 +6,5 @@ import slipp.stalk.domain.Member;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByMemberId(String memberId);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/slipp/stalk/service/MemberService.java
+++ b/src/main/java/slipp/stalk/service/MemberService.java
@@ -1,7 +1,7 @@
 package slipp.stalk.service;
 
 import org.springframework.stereotype.Service;
-import slipp.stalk.controller.exceptions.MemberIdAlreadyExistException;
+import slipp.stalk.controller.exceptions.MemberEmailAlreadyExistException;
 import slipp.stalk.controller.exceptions.MemberNotFoundException;
 import slipp.stalk.controller.exceptions.TokenAlreadyRegisterException;
 import slipp.stalk.controller.exceptions.TokenNotFoundException;
@@ -31,9 +31,9 @@ public class MemberService {
 
     @Transactional
     public Member create(Member body) {
-        memberRepository.findByMemberId(body.getMemberId())
+        memberRepository.findByEmail(body.getEmail())
                         .ifPresent(t -> {
-                            throw new MemberIdAlreadyExistException(t.getMemberId());
+                            throw new MemberEmailAlreadyExistException(t.getEmail());
                         });
         return memberRepository.save(body);
     }

--- a/src/main/resources/data-h2.sql
+++ b/src/main/resources/data-h2.sql
@@ -1,1 +1,1 @@
-INSERT INTO member (ID, MEMBER_ID, MEMBER_PASSWORD, MEMBER_NAME, MEMBER_EMAIL) values ((select next value for hibernate_sequence), 'gunju', 'test', '고건주', 'gunjuko92@gmail.com');
+INSERT INTO member (ID, MEMBER_PASSWORD, MEMBER_NAME, MEMBER_EMAIL) values ((select next value for hibernate_sequence), 'test', '고건주', 'gunjuko92@gmail.com');

--- a/src/test/java/slipp/stalk/controller/MemberControllerTest.java
+++ b/src/test/java/slipp/stalk/controller/MemberControllerTest.java
@@ -66,18 +66,6 @@ public class MemberControllerTest {
                .andExpect(status().isBadRequest());
     }
 
-    @Test
-    public void should_return_400_when_memberId_is_too_short() throws Exception {
-        CreateMemberDto body = mockCreateMemberDto();
-        body.setMemberId("ab");
-
-        mockMvc.perform(post("/members")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(writeBodyAsString(body)))
-               .andDo(print())
-               .andExpect(status().isBadRequest());
-    }
-
     private String writeBodyAsString(Object body) throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.writeValueAsString(body);
@@ -86,7 +74,6 @@ public class MemberControllerTest {
     private CreateMemberDto mockCreateMemberDto() {
         CreateMemberDto body = new CreateMemberDto();
         body.setEmail("gunju@slipp.com");
-        body.setMemberId("gunju");
         body.setName("고건주");
         body.setPassword("password");
         return body;
@@ -94,7 +81,6 @@ public class MemberControllerTest {
 
     private Optional<Member> mockMember() {
         Member member = new Member();
-        member.setMemberId("test");
         member.setPassword("password");
         member.setName("gunju");
         member.setEmail("gunju@slipp.com");

--- a/src/test/java/slipp/stalk/integration/api/MemberControllerIntegTest.java
+++ b/src/test/java/slipp/stalk/integration/api/MemberControllerIntegTest.java
@@ -23,7 +23,7 @@ public class MemberControllerIntegTest {
 
     @Test
     public void should_create_new_member() throws Exception {
-        CreateMemberDto body = createBody("slipp");
+        CreateMemberDto body = createBody("gunju@slipp.com");
         String path = createResource("/members", body);
 
         ResponseEntity<MemberDto> response = restTemplate.getForEntity(path, MemberDto.class);
@@ -31,7 +31,6 @@ public class MemberControllerIntegTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         MemberDto responseBody = response.getBody();
         assertThat(responseBody).isNotNull();
-        assertThat(responseBody.getMemberId()).isEqualTo(body.getMemberId());
         assertThat(responseBody.getName()).isEqualTo(body.getName());
         assertThat(responseBody.getEmail()).isEqualTo(body.getEmail());
 
@@ -41,15 +40,15 @@ public class MemberControllerIntegTest {
     }
 
     @Test
-    public void should_return_409_when_memberId_isAlready_exist() throws Exception {
-        CreateMemberDto body = createBody("gunju");
+    public void should_return_409_when_email_isAlready_exist() throws Exception {
+        CreateMemberDto body = createBody("gunjuko92@gmail.com");
         ResponseEntity<Void> response = restTemplate.postForEntity("/members", body, Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
     }
 
     private String createResource(String path, Object body) {
         ResponseEntity<Void> response = restTemplate.postForEntity(path, body, Void.class);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         return response.getHeaders().getLocation().getPath();
     }
 
@@ -63,12 +62,11 @@ public class MemberControllerIntegTest {
         assertThat(response.getStatusCode()).isEqualTo(status);
     }
 
-    private CreateMemberDto createBody(String memberId) {
+    private CreateMemberDto createBody(String email) {
         CreateMemberDto body = new CreateMemberDto();
-        body.setMemberId(memberId);
         body.setPassword("password");
         body.setName("hi");
-        body.setEmail(memberId + "@naver.com");
+        body.setEmail(email);
         return body;
     }
 }

--- a/src/test/java/slipp/stalk/service/MemberServiceTest.java
+++ b/src/test/java/slipp/stalk/service/MemberServiceTest.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import slipp.stalk.controller.exceptions.MemberIdAlreadyExistException;
+import slipp.stalk.controller.exceptions.MemberEmailAlreadyExistException;
 import slipp.stalk.controller.exceptions.MemberNotFoundException;
 import slipp.stalk.controller.exceptions.TokenAlreadyRegisterException;
 import slipp.stalk.controller.exceptions.TokenNotFoundException;
@@ -44,7 +44,7 @@ public class MemberServiceTest extends DataJpaIntegrationTest {
     public void get__return_member_when_member_is_exist() {
         Optional<Member> member = service.get(id);
         assertThat(member.isPresent()).isTrue();
-        assertThat(member.get().getMemberId()).isEqualTo("gunju");
+        assertThat(member.get().getName()).isEqualTo("고건주");
     }
 
     @Test
@@ -87,7 +87,6 @@ public class MemberServiceTest extends DataJpaIntegrationTest {
 
         long newId = saveTestData(MemberTestMother.memberBuilder()
                                                   .email("gunjuko@gmail.com")
-                                                  .memberId("new member")
                                                   .name("gunju ko")
                                                   .password("test")
                                                   .build()).getId();
@@ -116,18 +115,18 @@ public class MemberServiceTest extends DataJpaIntegrationTest {
 
     @Test
     public void create__should_throw_MemberIdAlreadyExistException_when_memberId_is_already_exist() throws Exception {
-        Member member = createMember("gunju");
+        Member member = createMember("gunjuko92@gmail.com");
 
         Throwable t = catchThrowable(() -> service.create(member));
-        assertThat(t).isInstanceOf(MemberIdAlreadyExistException.class);
+        assertThat(t).isInstanceOf(MemberEmailAlreadyExistException.class);
     }
 
     @Test
     public void create__should_create_new_member() throws Exception {
-        Member member = createMember("slipp");
+        Member member = createMember("gunju@slipp.com");
 
         Member result = service.create(member);
-        assertThat(result.getMemberId()).isEqualTo(member.getMemberId());
+        assertThat(result.getEmail()).isEqualTo(member.getEmail());
     }
 
     @Test
@@ -146,12 +145,11 @@ public class MemberServiceTest extends DataJpaIntegrationTest {
         assertThat(t).isInstanceOf(MemberNotFoundException.class);
     }
 
-    private Member createMember(String memberId) {
+    private Member createMember(String email) {
         Member member = new Member();
-        member.setMemberId(memberId);
         member.setPassword("password");
         member.setName("무명");
-        member.setEmail(memberId + "@naver.com");
+        member.setEmail(email);
         return member;
     }
 

--- a/src/test/java/slipp/stalk/support/MemberTestMother.java
+++ b/src/test/java/slipp/stalk/support/MemberTestMother.java
@@ -12,17 +12,11 @@ public class MemberTestMother {
     }
 
     public static class MemberBuilder {
-        private String memberId;
         private String password;
         private String name;
         private String email;
 
         private MemberBuilder() {
-        }
-
-        public MemberBuilder memberId(String memberId) {
-            this.memberId = memberId;
-            return this;
         }
 
         public MemberBuilder password(String password) {
@@ -42,7 +36,6 @@ public class MemberTestMother {
 
         public Member build() {
             Member member = new Member();
-            member.setMemberId(memberId);
             member.setPassword(password);
             member.setName(name);
             member.setEmail(email);


### PR DESCRIPTION
### Description

* 회원 테이블에서 member_id 필드를 삭제했습니다.
* 관련된 API도 수정되었습니다.

### APIS

##### 회원 조회

* API 호출 : GET /members/{id}
* API 호출 결과

```JSON
{
    "id": 1,
    "name": "고건주",
    "email": "gunjuko92@gmail.com"
}
```

##### 회원 생성

* API 호출 : POST /members
* API 호출 샘플

```
curl -X POST \
  http://localhost:8080/members \
  -H 'Content-Type: application/json' \
  -d '{
	"password": "test123",
	"name": "고건주",
	"email": "rhrjswn2@naver.com"
}'
```

